### PR TITLE
Use Alpine Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ local.properties
 /.DS_Store
 build
 cli/config.json
+.vagrant

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,27 @@
-FROM golang:wheezy
+FROM alpine:3.3
 
-RUN go get -u -v -t github.com/coreos/etcd/...
+ENV VERSION_ETCD=2.3.3 \
+    GOPATH=/tmp
 
-RUN go get -u -v -t github.com/tleyden/etcd-discovery/...
+RUN apk --update --no-cache upgrade && \
+    apk add --update --no-cache curl git && \
+    apk add --update --no-cache --repository http://alpine.gliderlabs.com/alpine/edge/community go && \
+    
+    curl -sSL https://github.com/coreos/etcd/releases/download/v${VERSION_ETCD}/etcd-v${VERSION_ETCD}-linux-amd64.tar.gz \
+    | tar xfz - -C /tmp && \
+    
+    mv /tmp/etcd-v${VERSION_ETCD}-linux-amd64/etcd /usr/bin/etcd && \
+    
+    go get -u -v -t github.com/tleyden/etcd-discovery/... && \
+    mv $GOPATH/bin/* /usr/bin && \
 
+    rm -rf /tmp/* && \
+    apk del git go && \
+    
+    addgroup etcdisco && \
+    adduser -D -g "" -s /bin/sh -G etcdisco etcdisco
+
+USER etcdisco
+WORKDIR /home/etcdisco
+
+CMD ash

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,23 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# use virtualbox of available providers automatically
+ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
+
+Vagrant.configure(2) do |config|
+  config.vm.box = "box-cutter/ubuntu1504-docker"
+  
+  # VBox configuration
+  config.vm.provider "virtualbox" do |vb|
+	# Display the VirtualBox GUI when booting the machine
+	vb.gui = false
+  end
+
+  config.vm.provision "shell", inline: <<-SHELL
+    apt-get update
+    apt-get dist-upgrade -y
+    apt-get autoremove -y
+
+    service docker start
+  SHELL
+end

--- a/run
+++ b/run
@@ -1,0 +1,1 @@
+docker run --rm -it --name etcd-discovery tleyden5iwx/etcd-discovery


### PR DESCRIPTION
This updates the image to use Alpine Linux and it gets the necessary `etcd` binary from official release pre-compiled so no need to get it with `go get`. Makes it easier to control versions as well. Image size is cut from 178 MB to 10 MB. Temporary image can be pulled from `https://hub.docker.com/r/matthewvalimaki/etcd-discovery/`.